### PR TITLE
Add recording link for The Curve open models talk

### DIFF
--- a/cv.yaml
+++ b/cv.yaml
@@ -341,7 +341,7 @@ talks:
   location: The Curve
   url: https://thecurve.goldengateinstitute.org/
   title: Open Models in 2025
-  details: "(\\href{https://docs.google.com/presentation/d/1f1Et0Mz8zb1yVCnCgdYSy4tAa0Kv_gKT4wPEg1XPdUA/edit?usp=sharing}{slides})"
+  details: "(\\href{https://docs.google.com/presentation/d/1f1Et0Mz8zb1yVCnCgdYSy4tAa0Kv_gKT4wPEg1XPdUA/edit?usp=sharing}{slides}, \\href{https://youtu.be/FUcilE5Gx_0}{recording})"
 - year: 2025
   month: October
   location: Conference on Language Modeling (COLM), ScalR Workshop


### PR DESCRIPTION
## Summary
- add the new recording link to the October 2025 The Curve talk entry

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f275de8c44832590796ca23e3d6c47