### PR TITLE
Fix CV colors in CI builds

### DIFF
--- a/.github/workflows/build-cv.yml
+++ b/.github/workflows/build-cv.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-cv.yml
+++ b/.github/workflows/build-cv.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-cv.yml
+++ b/.github/workflows/build-cv.yml
@@ -37,12 +37,6 @@ jobs:
             fontaxes mweights microtype colortbl multirow arydshln changepage \
             pgf float fancybox academicons fontawesome5 lm tcolorbox environ \
             trimspaces iftex l3kernel l3packages
-          # Pin moderncv to v2.3.1 to match local environment (v2.4.1 has color issues)
-          curl -L https://github.com/moderncv/moderncv/archive/refs/tags/v2.3.1.tar.gz | tar xz
-          sudo cp moderncv-2.3.1/*.sty moderncv-2.3.1/*.cls $(kpsewhich -var-value=TEXMFLOCAL)/tex/latex/moderncv/ 2>/dev/null || \
-          sudo mkdir -p $(kpsewhich -var-value=TEXMFLOCAL)/tex/latex/moderncv && \
-          sudo cp moderncv-2.3.1/*.sty moderncv-2.3.1/*.cls $(kpsewhich -var-value=TEXMFLOCAL)/tex/latex/moderncv/
-          sudo mktexlsr
 
       - name: Sync Python dependencies
         run: uv sync --frozen --no-dev --python 3.10

--- a/.github/workflows/build-cv.yml
+++ b/.github/workflows/build-cv.yml
@@ -52,29 +52,6 @@ jobs:
           make all
           make release
 
-      - name: Debug LaTeX color setup
-        run: |
-          echo "=== TeX Live Version ==="
-          tlmgr --version || true
-          echo ""
-          echo "=== moderncv.cls version (first 30 lines) ==="
-          head -30 "$(kpsewhich moderncv.cls)" || true
-          echo ""
-          echo "=== Color definitions in generated cv.tex ==="
-          grep -n "color" build/cv.tex | head -30 || true
-          echo ""
-          echo "=== moderncvcolor and moderncvstyle in cv.tex ==="
-          grep -n "moderncv" build/cv.tex || true
-          echo ""
-          echo "=== AtBeginDocument section ==="
-          grep -A5 "AtBeginDocument" build/cv.tex || true
-
-      - name: Upload PDF artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: cv-pdf
-          path: build/natolambert-cv*.pdf
-
       - name: Commit updated PDF
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.actor != 'github-actions[bot]'
         env:

--- a/.github/workflows/build-cv.yml
+++ b/.github/workflows/build-cv.yml
@@ -37,6 +37,11 @@ jobs:
             fontaxes mweights microtype colortbl multirow arydshln changepage \
             pgf float fancybox academicons fontawesome5 lm tcolorbox environ \
             trimspaces iftex l3kernel l3packages
+          # Pin moderncv to v2.3.1 (v2.4+ has faded heading colors)
+          curl -sL https://github.com/moderncv/moderncv/archive/refs/tags/v2.3.1.tar.gz | tar xz
+          sudo mkdir -p $(kpsewhich -var-value=TEXMFLOCAL)/tex/latex/moderncv
+          sudo cp moderncv-2.3.1/*.sty moderncv-2.3.1/*.cls $(kpsewhich -var-value=TEXMFLOCAL)/tex/latex/moderncv/
+          sudo mktexlsr
 
       - name: Sync Python dependencies
         run: uv sync --frozen --no-dev --python 3.10

--- a/.github/workflows/build-cv.yml
+++ b/.github/workflows/build-cv.yml
@@ -27,6 +27,7 @@ jobs:
 
       - name: Install LaTeX toolchain
         run: |
+          # brew update  # uncomment for minor potential for version fix
           brew install --cask basictex
           echo "/Library/TeX/texbin" >> $GITHUB_PATH
           eval "$(/usr/libexec/path_helper)"

--- a/.github/workflows/build-cv.yml
+++ b/.github/workflows/build-cv.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -38,6 +39,23 @@ jobs:
           make clean
           make all
           make release
+
+      - name: Debug LaTeX color setup
+        run: |
+          echo "=== TeX Live Version ==="
+          tlmgr --version || true
+          echo ""
+          echo "=== moderncv.cls version (first 30 lines) ==="
+          head -30 "$(kpsewhich moderncv.cls)" || true
+          echo ""
+          echo "=== Color definitions in generated cv.tex ==="
+          grep -n "color" build/cv.tex | head -30 || true
+          echo ""
+          echo "=== moderncvcolor and moderncvstyle in cv.tex ==="
+          grep -n "moderncv" build/cv.tex || true
+          echo ""
+          echo "=== AtBeginDocument section ==="
+          grep -A5 "AtBeginDocument" build/cv.tex || true
 
       - name: Commit updated PDF
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.actor != 'github-actions[bot]'

--- a/.github/workflows/build-cv.yml
+++ b/.github/workflows/build-cv.yml
@@ -57,6 +57,12 @@ jobs:
           echo "=== AtBeginDocument section ==="
           grep -A5 "AtBeginDocument" build/cv.tex || true
 
+      - name: Upload PDF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cv-pdf
+          path: build/natolambert-cv*.pdf
+
       - name: Commit updated PDF
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.actor != 'github-actions[bot]'
         env:

--- a/.github/workflows/build-cv.yml
+++ b/.github/workflows/build-cv.yml
@@ -28,8 +28,15 @@ jobs:
       - name: Install LaTeX toolchain
         run: |
           brew update
-          brew install --cask mactex-no-gui
+          brew install --cask basictex
           echo "/Library/TeX/texbin" >> $GITHUB_PATH
+          eval "$(/usr/libexec/path_helper)"
+          # Install required packages for moderncv
+          sudo tlmgr update --self
+          sudo tlmgr install moderncv lastpage mathabx fancyhdr etoolbox xcolor \
+            fontaxes mweights microtype colortbl multirow arydshln changepage \
+            pgf float fancybox academicons fontawesome5 lm tcolorbox environ \
+            trimspaces iftex l3kernel l3packages
 
       - name: Sync Python dependencies
         run: uv sync --frozen --no-dev --python 3.10

--- a/.github/workflows/build-cv.yml
+++ b/.github/workflows/build-cv.yml
@@ -33,7 +33,7 @@ jobs:
           eval "$(/usr/libexec/path_helper)"
           # Install required packages for moderncv
           sudo tlmgr update --self
-          sudo tlmgr install moderncv lastpage mathabx fancyhdr etoolbox xcolor \
+          sudo tlmgr install latexmk moderncv lastpage mathabx fancyhdr etoolbox xcolor \
             fontaxes mweights microtype colortbl multirow arydshln changepage \
             pgf float fancybox academicons fontawesome5 lm tcolorbox environ \
             trimspaces iftex l3kernel l3packages

--- a/.github/workflows/build-cv.yml
+++ b/.github/workflows/build-cv.yml
@@ -27,7 +27,6 @@ jobs:
 
       - name: Install LaTeX toolchain
         run: |
-          brew update
           brew install --cask basictex
           echo "/Library/TeX/texbin" >> $GITHUB_PATH
           eval "$(/usr/libexec/path_helper)"

--- a/.github/workflows/build-cv.yml
+++ b/.github/workflows/build-cv.yml
@@ -37,6 +37,12 @@ jobs:
             fontaxes mweights microtype colortbl multirow arydshln changepage \
             pgf float fancybox academicons fontawesome5 lm tcolorbox environ \
             trimspaces iftex l3kernel l3packages
+          # Pin moderncv to v2.3.1 to match local environment (v2.4.1 has color issues)
+          curl -L https://github.com/moderncv/moderncv/archive/refs/tags/v2.3.1.tar.gz | tar xz
+          sudo cp moderncv-2.3.1/*.sty moderncv-2.3.1/*.cls $(kpsewhich -var-value=TEXMFLOCAL)/tex/latex/moderncv/ 2>/dev/null || \
+          sudo mkdir -p $(kpsewhich -var-value=TEXMFLOCAL)/tex/latex/moderncv && \
+          sudo cp moderncv-2.3.1/*.sty moderncv-2.3.1/*.cls $(kpsewhich -var-value=TEXMFLOCAL)/tex/latex/moderncv/
+          sudo mktexlsr
 
       - name: Sync Python dependencies
         run: uv sync --frozen --no-dev --python 3.10

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# CV Build Notes
+
+## LaTeX Setup
+
+**moderncv version**: Must use v2.3.1. Version 2.4.1 has a color regression where custom `color1`/`color2`/`color3` definitions are ignored.
+
+**Local setup** (new laptop):
+```bash
+brew install --cask basictex
+sudo tlmgr update --self
+sudo tlmgr install latexmk moderncv lastpage mathabx ...  # see CI workflow for full list
+
+# Pin moderncv to v2.3.1
+curl -L https://github.com/moderncv/moderncv/archive/refs/tags/v2.3.1.tar.gz | tar xz
+sudo cp moderncv-2.3.1/*.sty moderncv-2.3.1/*.cls $(kpsewhich -var-value=TEXMFLOCAL)/tex/latex/moderncv/
+sudo mktexlsr
+```
+
+## CI Notes
+
+- Uses BasicTeX (faster than full MacTeX, ~100MB vs ~4GB)
+- `brew update` skipped for speed; uncomment if install fails
+- PDF artifact uploaded on PR builds for inspection
+
+## Known Issues
+
+- **moderncv v2.4.1 color bug**: Custom colors defined via `\definecolor{color1}` after `\moderncvcolor{blue}` are silently ignored. Affects headings and name color. Pinning to v2.3.1 fixes this.
+
+## Bibliography
+
+- `selected={true}` highlights a publication; `selected={false}` or omitting the field does not
+- `_venue` is optional, defaults to "Preprint"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,18 +2,33 @@
 
 ## LaTeX Setup
 
-**moderncv version**: Must use v2.3.1. Version 2.4.1 has a color regression where custom `color1`/`color2`/`color3` definitions are ignored.
+**moderncv version**: Must use v2.3.1. Version 2.4+ changed internal color handling - custom `color1`/`color2`/`color3` definitions result in faded colors. CI pins to v2.3.1.
 
 **Local setup** (new laptop):
 ```bash
+# Install BasicTeX
 brew install --cask basictex
-sudo tlmgr update --self
-sudo tlmgr install latexmk moderncv lastpage mathabx ...  # see CI workflow for full list
 
-# Pin moderncv to v2.3.1
+# Add to PATH (or restart terminal)
+eval "$(/usr/libexec/path_helper)"
+
+# Install required packages
+sudo tlmgr update --self
+sudo tlmgr install latexmk moderncv lastpage mathabx fancyhdr etoolbox xcolor \
+  fontaxes mweights microtype colortbl multirow arydshln changepage \
+  pgf float fancybox academicons fontawesome5 lm tcolorbox environ \
+  trimspaces iftex l3kernel l3packages
+
+# Pin moderncv to v2.3.1 (for correct heading colors)
 curl -L https://github.com/moderncv/moderncv/archive/refs/tags/v2.3.1.tar.gz | tar xz
+sudo mkdir -p $(kpsewhich -var-value=TEXMFLOCAL)/tex/latex/moderncv
 sudo cp moderncv-2.3.1/*.sty moderncv-2.3.1/*.cls $(kpsewhich -var-value=TEXMFLOCAL)/tex/latex/moderncv/
 sudo mktexlsr
+rm -rf moderncv-2.3.1
+
+# Verify version
+head -15 "$(kpsewhich moderncv.cls)" | grep ProvidesClass
+# Should show: v2.3.1
 ```
 
 ## CI Notes

--- a/templates/latex/cv.tex
+++ b/templates/latex/cv.tex
@@ -30,12 +30,11 @@
 \usepackage{mathabx}
 
 \moderncvstyle{<< style >>}
-% Define custom colors BEFORE moderncvcolor so they aren't overwritten
+\moderncvcolor{<< color >>}
+% Override colors by redefining after moderncvcolor sets them
 \definecolor{color1}{rgb}{<<color1>>}
 \definecolor{color2}{rgb}{<<color2>>}
 \definecolor{color3}{rgb}{<<color3>>}
-% Don't call \moderncvcolor since we're using custom colors
-% \moderncvcolor{<< color >>}
 %\renewcommand{\familydefault}{\sfdefault}
 
 \usepackage[top=.75in, bottom=.75in, left=.7in, right=.7in]{geometry}

--- a/templates/latex/cv.tex
+++ b/templates/latex/cv.tex
@@ -29,9 +29,10 @@
 % Load mathabx before moderncv color definitions to avoid conflicts
 \usepackage{mathabx}
 
-\moderncvstyle{<< style >>}
+% moderncvcolor must be called BEFORE moderncvstyle in newer versions (v2.4+)
 \moderncvcolor{<< color >>}
-% Override colors by redefining after moderncvcolor sets them
+\moderncvstyle{<< style >>}
+% Override colors by redefining after moderncv sets them
 \definecolor{color1}{rgb}{<<color1>>}
 \definecolor{color2}{rgb}{<<color2>>}
 \definecolor{color3}{rgb}{<<color3>>}

--- a/templates/latex/cv.tex
+++ b/templates/latex/cv.tex
@@ -30,13 +30,12 @@
 \usepackage{mathabx}
 
 \moderncvstyle{<< style >>}
-\moderncvcolor{<< color >>}
-% Define custom colors after moderncv loads, using AtBeginDocument to ensure they take effect
-\AtBeginDocument{%
-  \definecolor{color1}{rgb}{<<color1>>}%
-  \definecolor{color2}{rgb}{<<color2>>}%
-  \definecolor{color3}{rgb}{<<color3>>}%
-}
+% Define custom colors BEFORE moderncvcolor so they aren't overwritten
+\definecolor{color1}{rgb}{<<color1>>}
+\definecolor{color2}{rgb}{<<color2>>}
+\definecolor{color3}{rgb}{<<color3>>}
+% Don't call \moderncvcolor since we're using custom colors
+% \moderncvcolor{<< color >>}
 %\renewcommand{\familydefault}{\sfdefault}
 
 \usepackage[top=.75in, bottom=.75in, left=.7in, right=.7in]{geometry}

--- a/templates/latex/cv.tex
+++ b/templates/latex/cv.tex
@@ -31,9 +31,12 @@
 
 \moderncvstyle{<< style >>}
 \moderncvcolor{<< color >>}
-\definecolor{color1}{rgb}{<<color1>>}
-\definecolor{color2}{rgb}{<<color2>>}
-\definecolor{color3}{rgb}{<<color3>>}
+% Define custom colors after moderncv loads, using AtBeginDocument to ensure they take effect
+\AtBeginDocument{%
+  \definecolor{color1}{rgb}{<<color1>>}%
+  \definecolor{color2}{rgb}{<<color2>>}%
+  \definecolor{color3}{rgb}{<<color3>>}%
+}
 %\renewcommand{\familydefault}{\sfdefault}
 
 \usepackage[top=.75in, bottom=.75in, left=.7in, right=.7in]{geometry}


### PR DESCRIPTION
## Summary
- Move custom color definitions into `\AtBeginDocument` hook
- This ensures colors are defined after moderncv has finished its initialization
- Previous fix (moving mathabx) didn't work - this is an alternative approach

## Why this should work
The moderncv class may re-apply default colors during initialization. By defining our custom colors in `\AtBeginDocument`, they're guaranteed to be set after all preamble processing is complete.

## Test plan
- [ ] Merge and verify CI-built PDF has blue colors in headings and name

🤖 Generated with [Claude Code](https://claude.com/claude-code)