### PR TITLE
Refresh Scholar cache in CI and update mentorship entries

### DIFF
--- a/.github/workflows/build-cv.yml
+++ b/.github/workflows/build-cv.yml
@@ -25,11 +25,27 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
+      - name: Prepare TeX Live cache directory
+        run: |
+          sudo mkdir -p /usr/local/texlive
+          sudo chown -R "$(whoami)" /usr/local/texlive
+
+      - name: Cache TeX Live
+        uses: actions/cache@v4
+        id: cache-texlive
+        with:
+          path: /usr/local/texlive
+          key: texlive-macos-${{ hashFiles('.github/workflows/build-cv.yml') }}
+
       - name: Install LaTeX toolchain
         run: |
+          if [ "${{ steps.cache-texlive.outputs.cache-hit }}" = "true" ]; then
+            echo "Cache hit - skipping LaTeX installation"
+            exit 0
+          fi
+
           # brew update  # uncomment for minor potential for version fix
           brew install --cask basictex
-          echo "/Library/TeX/texbin" >> $GITHUB_PATH
           eval "$(/usr/libexec/path_helper)"
           # Install required packages for moderncv
           sudo tlmgr update --self
@@ -39,9 +55,22 @@ jobs:
             trimspaces iftex l3kernel l3packages
           # Pin moderncv to v2.3.1 (v2.4+ has faded heading colors)
           curl -sL https://github.com/moderncv/moderncv/archive/refs/tags/v2.3.1.tar.gz | tar xz
-          sudo mkdir -p $(kpsewhich -var-value=TEXMFLOCAL)/tex/latex/moderncv
-          sudo cp moderncv-2.3.1/*.sty moderncv-2.3.1/*.cls $(kpsewhich -var-value=TEXMFLOCAL)/tex/latex/moderncv/
+          sudo mkdir -p "$(kpsewhich -var-value=TEXMFLOCAL)/tex/latex/moderncv"
+          sudo cp moderncv-2.3.1/*.sty moderncv-2.3.1/*.cls "$(kpsewhich -var-value=TEXMFLOCAL)/tex/latex/moderncv/"
           sudo mktexlsr
+
+      - name: Set up LaTeX PATH
+        run: |
+          TEXLIVE_BIN=$(find /usr/local/texlive -type d -name "bin" -exec find {} -type d -name "*-darwin*" \; 2>/dev/null | head -1)
+          if [ -z "$TEXLIVE_BIN" ] && [ ! -e /Library/TeX/texbin ]; then
+            echo "TeX Live installation not found in cache or standard symlink path"
+            exit 1
+          fi
+          echo "Found TeX Live bin: $TEXLIVE_BIN"
+          if [ -n "$TEXLIVE_BIN" ]; then
+            echo "$TEXLIVE_BIN" >> $GITHUB_PATH
+          fi
+          echo "/Library/TeX/texbin" >> $GITHUB_PATH
 
       - name: Sync Python dependencies
         run: uv sync --frozen --no-dev --python 3.10

--- a/.github/workflows/build-cv.yml
+++ b/.github/workflows/build-cv.yml
@@ -47,6 +47,8 @@ jobs:
         run: uv sync --frozen --no-dev --python 3.10
 
       - name: Build CV
+        env:
+          REFRESH_SCHOLAR_STATS: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.actor != 'github-actions[bot]' && '1' || '' }}
         run: |
           make clean
           make all
@@ -59,6 +61,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add stats/google_scholar_stats.json
           git add build/natolambert-cv.pdf
           git add -u build || true
           if git diff --cached --quiet; then

--- a/.github/workflows/build-cv.yml
+++ b/.github/workflows/build-cv.yml
@@ -51,7 +51,6 @@ jobs:
           eval "$(/usr/libexec/path_helper)"
           sudo tlmgr option repository "$TEXLIVE_REPOSITORY"
           # Install required packages for moderncv
-          sudo tlmgr update --self --repository "$TEXLIVE_REPOSITORY"
           sudo tlmgr install --repository "$TEXLIVE_REPOSITORY" latexmk moderncv lastpage mathabx fancyhdr etoolbox xcolor \
             fontaxes mweights microtype colortbl multirow arydshln changepage \
             pgf float fancybox academicons fontawesome5 lm tcolorbox environ \

--- a/.github/workflows/build-cv.yml
+++ b/.github/workflows/build-cv.yml
@@ -44,12 +44,15 @@ jobs:
             exit 0
           fi
 
+          TEXLIVE_REPOSITORY="https://mirror.ctan.org/systems/texlive/tlnet"
+
           # brew update  # uncomment for minor potential for version fix
           brew install --cask basictex
           eval "$(/usr/libexec/path_helper)"
+          sudo tlmgr option repository "$TEXLIVE_REPOSITORY"
           # Install required packages for moderncv
-          sudo tlmgr update --self
-          sudo tlmgr install latexmk moderncv lastpage mathabx fancyhdr etoolbox xcolor \
+          sudo tlmgr update --self --repository "$TEXLIVE_REPOSITORY"
+          sudo tlmgr install --repository "$TEXLIVE_REPOSITORY" latexmk moderncv lastpage mathabx fancyhdr etoolbox xcolor \
             fontaxes mweights microtype colortbl multirow arydshln changepage \
             pgf float fancybox academicons fontawesome5 lm tcolorbox environ \
             trimspaces iftex l3kernel l3packages

--- a/.github/workflows/build-cv.yml
+++ b/.github/workflows/build-cv.yml
@@ -44,13 +44,14 @@ jobs:
             exit 0
           fi
 
-          TEXLIVE_REPOSITORY="https://mirror.ctan.org/systems/texlive/tlnet"
+          TEXLIVE_REPOSITORY=$(curl -fsSL -o /dev/null -w '%{url_effective}' https://mirror.ctan.org/systems/texlive/tlnet)
+          echo "Using TeX Live repository: $TEXLIVE_REPOSITORY"
 
           # brew update  # uncomment for minor potential for version fix
           brew install --cask basictex
           eval "$(/usr/libexec/path_helper)"
-          sudo tlmgr option repository "$TEXLIVE_REPOSITORY"
           # Install required packages for moderncv
+          sudo tlmgr update --self --repository "$TEXLIVE_REPOSITORY"
           sudo tlmgr install --repository "$TEXLIVE_REPOSITORY" latexmk moderncv lastpage mathabx fancyhdr etoolbox xcolor \
             fontaxes mweights microtype colortbl multirow arydshln changepage \
             pgf float fancybox academicons fontawesome5 lm tcolorbox environ \

--- a/README.md
+++ b/README.md
@@ -77,4 +77,4 @@ new documents to another repository with `make jekyll` and `make push`.
    normal LaTeX. See `generate.py` for details.
 
 ## Automation
-Pushes to `main` trigger the `Build CV` GitHub Action (`.github/workflows/build-cv.yml`) which installs LaTeX, syncs Python dependencies with uv, runs `make all` followed by `make release`, and commits the refreshed `build/natolambert-cv.pdf` when changes are detected. The workflow also runs on pull requests for verification without committing the artifact.
+Pushes to `main` trigger the `Build CV` GitHub Action (`.github/workflows/build-cv.yml`) which installs LaTeX, syncs Python dependencies with uv, refreshes the Google Scholar cache during the build, runs `make all` followed by `make release`, and commits updated copies of `stats/google_scholar_stats.json` and `build/natolambert-cv.pdf` when changes are detected. The workflow also runs on pull requests for verification without refreshing the Scholar cache or committing artifacts.

--- a/cv.yaml
+++ b/cv.yaml
@@ -553,6 +553,13 @@ talks:
 
 advising:
   - year: 2025
+    name: Florian Brand
+    details: "(Interconnects Analyst)"
+    url: https://florianbrand.de
+  - year: 2025
+    name: Sharan Maiya
+    url: https://sharanmaiya.com/
+  - year: 2025
     name: Daniel Marta
     details: "(Thesis Committee Member)"
     url: https://daniellsm.github.io/

--- a/stats/google_scholar_stats.json
+++ b/stats/google_scholar_stats.json
@@ -1,5 +1,5 @@
 {
-  "h_index": 34,
-  "citations": 7512,
-  "updated": "2025-10-16"
+  "h_index": 39,
+  "citations": 10327,
+  "updated": "2026-03-08"
 }


### PR DESCRIPTION
## Summary
- refresh the Google Scholar cache on non-bot pushes to `main` and commit the updated cache JSON with the canonical PDF
- update the tracked Google Scholar stats to the latest fetched values
- add 2025 mentorship entries for Florian Brand and Sharan Maiya

## Verification
- `uv run --frozen python ./generate.py cv.yaml`
- workflow YAML parses successfully via `uv run --frozen python - <<'PY' ... yaml.safe_load(...)`