### PR TITLE
Disable Scholar stats refresh in CI

### DIFF
--- a/.github/workflows/build-cv.yml
+++ b/.github/workflows/build-cv.yml
@@ -79,8 +79,6 @@ jobs:
         run: uv sync --frozen --no-dev --python 3.10
 
       - name: Build CV
-        env:
-          REFRESH_SCHOLAR_STATS: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.actor != 'github-actions[bot]' && '1' || '' }}
         run: |
           make clean
           make all

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,17 @@ Add co-author URLs to `author_urls` in `cv.yaml` if not already present.
 - Google Scholar ID: `O4jW7BsAAAAJ` — use the `scholarly` Python library (already a dependency) to scrape publications.
 - Talk details (titles, slides links) can be found at natolambert.com/slides (data loaded from `data/slides-data.json`).
 
+## Google Scholar Stats
+
+Scholar stats (h-index, citations) are cached in `stats/google_scholar_stats.json`.
+This must be refreshed **locally** — it hangs in CI because Google blocks cloud IPs.
+
+```bash
+REFRESH_SCHOLAR_STATS=1 make all
+```
+
+When updating the CV, check if scholar stats are stale (look at the `updated` field in the JSON) and refresh if older than ~1 month.
+
 ## Notes
 
 - Text in `cv.yaml` uses LaTeX formatting (e.g. `\\href{url}{text}`, `\\textbf{}`).


### PR DESCRIPTION
## Summary
- Remove `REFRESH_SCHOLAR_STATS` env var from CI workflow to prevent `scholarly` from hanging (Google blocks cloud IPs)
- Add documentation in CLAUDE.md for refreshing scholar stats locally

Scholar stats JSON was already updated today (2026-03-08).

## Test plan
- [ ] CI build completes without hanging
- [ ] Cached scholar stats are used correctly in the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)