### PR TITLE
[codex] Update CV recent work

### DIFF
--- a/cv.yaml
+++ b/cv.yaml
@@ -123,6 +123,9 @@ service:
     year: 2017
 
 repos:
+  - repo_url: https://github.com/natolambert/colloquium
+    year: 2026
+    desc: Markdown-native slide tool for research talks
   - repo_url: https://github.com/natolambert/rlhf-book
     year: 2025
     desc: Book on RLHF
@@ -358,6 +361,12 @@ teaching:
 
 talks:
 - year: 2026
+  month: March
+  location: SALA 2026, Quito, Ecuador
+  url: https://lasala.ai/
+  title: An Introduction to Reinforcement Learning from Human Feedback and Post-training
+  details: "(\\href{https://rlhfbook.com/teach/SALA-2026/}{slides})"
+- year: 2026
   month: February
   location: LTI Colloquium @ Carnegie Mellon University
   title: Building OLMo in the Era of Agents
@@ -553,6 +562,10 @@ talks:
 
 advising:
   - year: 2025
+    name: Michael Noukhovitch
+    details: "(Ai2 Research Intern `25)"
+    url: https://mnoukhov.github.io/
+  - year: 2025
     name: Florian Brand
     details: "(Interconnects Analyst)"
     url: https://florianbrand.de
@@ -644,8 +657,10 @@ all_publications:
   author_urls:
     'Valentina Pyatkin': 'https://valentinapy.github.io/'
     'Jacob Morrison': 'https://jacobmorrison.com/'
+    'Florian Brand': 'https://florianbrand.de'
     'Shengyi Huang': 'https://costa.sh/'
     'Hamish Ivison': 'https://ivison.id.au/'
+    'Michael Noukhovitch': 'https://mnoukhov.github.io/'
     'Faeze Brahman': 'https://fabrahman.github.io/'
     'Lester James V. Miranda': 'https://ljvmiranda921.github.io/'
     'Alisa Liu': 'https://alisawuffles.github.io/'

--- a/publications/all.bib
+++ b/publications/all.bib
@@ -1,3 +1,49 @@
+@misc{lambert2026atom,
+      title={The ATOM Report: Measuring the Open Language Model Ecosystem},
+      author={Nathan Lambert and Florian Brand},
+      year={2026},
+      eprint={2604.07190},
+      archivePrefix={arXiv},
+      primaryClass={cs.CY},
+      _venue={arXiv Preprint},
+      url={https://arxiv.org/abs/2604.07190},
+      selected={true},
+}
+
+@misc{merrill2026olmohybrid,
+      title={Olmo Hybrid: From Theory to Practice and Back},
+      author={William Merrill and Yanhong Li and Tyler Romero and Anej Svete and Caia Costello and Pradeep Dasigi and Dirk Groeneveld and David Heineman and Bailey Kuehl and Nathan Lambert and Chuan Li and Kyle Lo and Saumya Malik and DJ Matusz and Benjamin Minixhofer and Jacob Morrison and Luca Soldaini and Finbarr Timbers and Pete Walsh and Noah A. Smith and Hannaneh Hajishirzi and Ashish Sabharwal},
+      year={2026},
+      eprint={2604.03444},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG},
+      _venue={arXiv Preprint},
+      url={https://arxiv.org/abs/2604.03444},
+}
+
+@misc{graf2026turnwise,
+      title={TurnWise: The Gap between Single- and Multi-turn Language Model Capabilities},
+      author={Victoria Graf and Valentina Pyatkin and Nouha Dziri and Nathan Lambert and Hannaneh Hajishirzi},
+      year={2026},
+      eprint={2603.16759},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      _venue={arXiv Preprint},
+      url={https://arxiv.org/abs/2603.16759},
+}
+
+@misc{xiao2026metarlsearch,
+      title={Meta-Reinforcement Learning with Self-Reflection for Agentic Search},
+      author={Teng Xiao and Yige Yuan and Hamish Ivison and Huaisheng Zhu and Faeze Brahman and Nathan Lambert and Pradeep Dasigi and Noah A. Smith and Hannaneh Hajishirzi},
+      year={2026},
+      eprint={2603.11327},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG},
+      _venue={arXiv Preprint},
+      url={https://arxiv.org/abs/2603.11327},
+      codeurl={https://github.com/tengxiao1/MR-Search},
+}
+
 @article{olmo2025olmo,
   title={Olmo 3},
   author={Team Olmo and Allyson Ettinger and Amanda Bertsch and Bailey Kuehl and David Graham and David Heineman and Dirk Groeneveld and Faeze Brahman and Finbarr Timbers and Hamish Ivison and Jacob Morrison and Jake Poznanski and Kyle Lo and Luca Soldaini and Matt Jordan and Mayee Chen and Michael Noukhovitch and Nathan Lambert and Pete Walsh and Pradeep Dasigi and Robert Berry and Saumya Malik and Saurabh Shah and Scott Geng and Shane Arora and Shashank Gupta and Taira Anderson and Teng Xiao and Tyler Murray and Tyler Romero and Victoria Graf and Akari Asai and Akshita Bhagia and Alexander Wettig and Alisa Liu and Aman Rangapur and Chloe Anastasiades and Costa Huang and Dustin Schwenk and Harsh Trivedi and Ian Magnusson and Jaron Lochner and Jiacheng Liu and Lester James V. Miranda and Maarten Sap and Malia Morgan and Michael Schmitz and Michal Guerquin and Michael Wilson and Regan Huff and Ronan Le Bras and Rui Xin and Rulin Shao and Sam Skjonsberg and Shannon Zejiang Shen and Shuyue Stella Li and Tucker Wilde and Valentina Pyatkin and Will Merrill and Yapei Chang and Yuling Gu and Zhiyuan Zeng and Ashish Sabharwal and Luke Zettlemoyer and Pang Wei Koh and Ali Farhadi and Noah A. Smith and Hannaneh Hajishirzi},
@@ -15,6 +61,13 @@
   _venue={arXiv Preprint},
   url={https://arxiv.org/abs/2511.01689},
   codeurl={https://github.com/maiush/OpenCharacterTraining},
+}
+@misc{curtis2025researchagenda,
+  title={Research Agenda for Sociotechnical Approaches to AI Safety},
+  author={Samuel Curtis and Ravi Iyer and Cameron Domenico Kirk-Giannini and Victoria Krakovna and David Krueger and Nathan Lambert and Bruno Marnette and Colleen McKenzie and Julian Michael and Evan Miyazono and Noyuri Mima and Aviv Ovadya and Luke Thorburn and Vehbi Deger Turan},
+  year={2025},
+  _venue={SSRN},
+  url={https://ssrn.com/abstract=5097286},
 }
 @misc{pyatkin2025generalizingverifiableinstructionfollowing,
       title={Generalizing Verifiable Instruction Following}, 
@@ -40,8 +93,9 @@
   title={RewardBench 2: Advancing Reward Model Evaluation},
   author={Malik, Saumya and Pyatkin, Valentina and Land, Sander and Morrison, Jacob and Smith, Noah A and Hajishirzi, Hannaneh and Lambert, Nathan},
   journal={arXiv preprint arXiv:2506.01937},
-  year={2025},
-  _venue={arXiv Preprint},
+  year={2026},
+  _venue={ICLR},
+  codeurl={https://github.com/allenai/reward-bench},
 }
 @article{lambert2025reinforcement,
   title={Reinforcement Learning from Human Feedback},
@@ -57,10 +111,10 @@
   title={2 OLMo 2 Furious},
     author={Team OLMo and Pete Walsh and Luca Soldaini and Dirk Groeneveld and Kyle Lo and Shane Arora and Akshita Bhagia and Yuling Gu and Shengyi Huang and Matt Jordan and Nathan Lambert and Dustin Schwenk and Oyvind Tafjord and Taira Anderson and David Atkinson and Faeze Brahman and Christopher Clark and Pradeep Dasigi and Nouha Dziri and Michal Guerquin and Hamish Ivison and Pang Wei Koh and Jiacheng Liu and Saumya Malik and William Merrill and Lester James V. Miranda and Jacob Morrison and Tyler Murray and Crystal Nam and Valentina Pyatkin and Aman Rangapur and Michael Schmitz and Sam Skjonsberg and David Wadden and Christopher Wilhelm and Michael Wilson and Luke Zettlemoyer and Ali Farhadi and Noah A. Smith and Hannaneh Hajishirzi},
   journal={arXiv preprint arXiv:2501.00656},
-  year={2024},
-  _venue={arXiv Preprint},
+  year={2025},
+  _venue={COLM},
   url={https://arxiv.org/abs/2501.00656},
-  codeurl={https://github.com/allenai/molmo},
+  codeurl={https://github.com/allenai/OLMo},
   selected={true},
 }
 
@@ -91,9 +145,9 @@
     Pradeep Dasigi and 
     Hannaneh Hajishirzi
   },
-  year = {2024},
+  year = {2025},
   email = {tulu@allenai.org},
-  _venue = {Technical Report},
+  _venue = {COLM},
   url = {https://arxiv.org/abs/2411.15124},
   codeurl = {https://github.com/allenai/open-instruct},
   selected={true},

--- a/stats/google_scholar_stats.json
+++ b/stats/google_scholar_stats.json
@@ -1,5 +1,5 @@
 {
-  "h_index": 39,
-  "citations": 10327,
-  "updated": "2026-03-08"
+  "h_index": 40,
+  "citations": 11453,
+  "updated": "2026-05-10"
 }


### PR DESCRIPTION
## Summary

- Add recent publications from Google Scholar / arXiv, including ATOM, OLMo Hybrid, TurnWise, MR-Search, and a sociotechnical AI safety research agenda.
- Mark ATOM as representative and add RewardBench 2 code link to `allenai/reward-bench`.
- Add SALA 2026 talk, Michael Noukhovitch mentorship, and the `natolambert/colloquium` repository.
- Refresh cached Google Scholar stats to 11,453 citations and h-index 40.

## Validation

- Parsed `cv.yaml` with PyYAML.
- Parsed `publications/all.bib` with the repo's BibTeX parser; 51 entries.
- Ran `make all` after the RewardBench 2 code-link update and generated the dated PDF.

## Notes

The local build was run with `HF_HUB_OFFLINE=1`, so Hugging Face artifact like-count refreshes were intentionally skipped during generation.